### PR TITLE
fix usage of image urls with parentheses

### DIFF
--- a/js/slimbox2.js
+++ b/js/slimbox2.js
@@ -190,7 +190,7 @@
 
 	function animateBox() {
 		center.className = "";
-		$(image).css({backgroundImage: "url(" + activeURL + ")", visibility: "hidden", display: ""});
+		$(image).css({backgroundImage: 'url("' + activeURL + '")', visibility: "hidden", display: ""});
 		$(sizer).width(preload.width);
 		$([sizer, prevLink, nextLink]).height(preload.height);
 


### PR DESCRIPTION
Currently it is not possible to display images containing parentheses in the url.
Using quotes for background-image's url fixes that issue (example: background-image: url("my-link(1).jpg")).
